### PR TITLE
fix: mark unknown validity boundaries invalid

### DIFF
--- a/test/test_validity_dates.py
+++ b/test/test_validity_dates.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+import pytest
+
+from veronique.data_types import TYPES
+from veronique.db import VALID_FROM, VALID_UNTIL
+from veronique.objects import Claim, Plain
+
+
+def date_prop(id_=0):
+    return SimpleNamespace(id=id_, data_type=TYPES["date"])
+
+
+def test_unknown_regular_date_is_still_allowed():
+    assert Plain.from_form(date_prop(), {"value": "????"}).value == "????-??-??"
+
+
+@pytest.mark.parametrize("verb_id", [VALID_FROM, VALID_UNTIL])
+def test_unknown_validity_boundary_is_allowed_in_form(verb_id):
+    assert Plain.from_form(date_prop(verb_id), {"value": "????"}).value == "????-??-??"
+
+
+def claim_value(value):
+    return [SimpleNamespace(object=SimpleNamespace(value=value))]
+
+
+def test_unknown_valid_from_makes_claim_invalid():
+    assert Claim(1)._get_invalid({VALID_FROM: claim_value("????-??-??")}) == (
+        "????-??-??",
+        None,
+    )
+
+
+def test_unknown_valid_until_makes_claim_invalid():
+    assert Claim(1)._get_invalid({VALID_UNTIL: claim_value("????-??-??")}) == (
+        None,
+        "????-??-??",
+    )

--- a/veronique/objects.py
+++ b/veronique/objects.py
@@ -809,12 +809,18 @@ class Claim(Model):
         today = date.today()
         if (
             VALID_FROM in data
-            and NonOmniscientDate(data[VALID_FROM][0].object.value).definitely_after(today)
+            and (
+                data[VALID_FROM][0].object.value == "????-??-??"
+                or NonOmniscientDate(data[VALID_FROM][0].object.value).definitely_after(today)
+            )
         ):
             not_yet_valid = data[VALID_FROM][0].object.value
         elif (
             VALID_UNTIL in data
-            and NonOmniscientDate(data[VALID_UNTIL][0].object.value).definitely_before(today)
+            and (
+                data[VALID_UNTIL][0].object.value == "????-??-??"
+                or NonOmniscientDate(data[VALID_UNTIL][0].object.value).definitely_before(today)
+            )
         ):
             no_longer_valid = data[VALID_UNTIL][0].object.value
         return not_yet_valid, no_longer_valid


### PR DESCRIPTION
Closes #59.

Summary:
- mark claims with fully unknown `valid from` / `valid until` boundaries as invalid
- keep fully unknown validity boundary form values accepted, so they can invalidate the claim rather than be rejected at input time
- keep fully unknown regular date values valid
- add focused tests for the claim-invalid behavior and form parsing control cases

Validation:
- `uv run --group test pytest test/test_validity_dates.py test/test_nomnidate.py`
- `git diff --check`
- `python -m py_compile veronique/objects.py test/test_validity_dates.py`